### PR TITLE
Add advanced converting of temperatures to detect without degree symbol

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -96,13 +96,18 @@ async function updateContentScript() {
     }
     
     // Load 'auto convert' setting
-    let data = await browser.storage.local.get('allowAuto');
+    let data = await browser.storage.local.get(['allowAuto', 'allowAutoAdvanced']);
     
-    // Sets default value if 'auto convert' is not set
-    if (typeof data.allowAuto == 'undefined') {
-        browser.storage.local.set({
-            allowAuto: true
-        });
+    // Sets default values if 'auto convert' or 'auto convert advanced' are not set
+    if ((typeof data.allowAuto == 'undefined') || (typeof data.allowAutoAdvanced == 'undefined')) {
+        const newSettings = {};
+        if (typeof data.allowAuto == 'undefined') {
+            newSettings.allowAuto = true;
+        }
+        if (typeof data.allowAutoAdvanced == 'undefined') {
+            newSettings.allowAutoAdvanced = false;
+        }
+        browser.storage.local.set(newSettings);
         return;
     }
     
@@ -124,7 +129,7 @@ async function updateContentScript() {
 // Handles changes to storage API
 function handleStorageChange(changes, area) {
     // Triggers enable/disable of auto convert
-    if (typeof changes.allowAuto != 'undefined') {
+    if ((typeof changes.allowAuto != 'undefined') || (typeof changes.allowAutoAdvanced != 'undefined')) {
         updateContentScript();
     }
 }

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -20,6 +20,18 @@
             <section class="panel-section help-row">
                 Scan website for temperatures and insert the converted temperature automatically
             </section>
+            <hr>
+            <section class="panel-section has-help">
+                <label>Automatically convert temperatures - Advanced</label>
+                <div>
+                    <label><input type="radio" name="allowAutoAdvanced" value="true"> Allow</label>
+                    <label><input type="radio" name="allowAutoAdvanced" value="false"> Deny</label>
+                </div>
+            </section>
+            <section class="panel-section help-row">
+                Expand the automatic converting of temperatures to include temperatures formatted without degree symbol (e.g. "180C" or "180 c")<br>
+                Only applies if "Automatically convert temperatures" is set to "Allow"
+            </section>
         </form>
         <script src="options.js"></script>
     </body>

--- a/firefox/options/options.js
+++ b/firefox/options/options.js
@@ -5,13 +5,15 @@
 // Save settings
 function saveOptions() {
     browser.storage.local.set({
-        allowAuto: toBoolean(document.settings.allowAuto.value)
+        allowAuto: toBoolean(document.settings.allowAuto.value),
+        allowAutoAdvanced: toBoolean(document.settings.allowAutoAdvanced.value)
     });
 }
 
 // Load settings from storage
 function restoreOptions(item) {
     document.settings.allowAuto.value = item.allowAuto;
+    document.settings.allowAutoAdvanced.value = item.allowAutoAdvanced;
 }
 
 // Convert string to boolean
@@ -23,5 +25,5 @@ function toBoolean(string) {
     }
 }
 
-browser.storage.local.get('allowAuto', restoreOptions);
+browser.storage.local.get(['allowAuto', 'allowAutoAdvanced'], restoreOptions);
 document.querySelector('form').addEventListener('change', saveOptions);

--- a/firefox/scripts/content_script.js
+++ b/firefox/scripts/content_script.js
@@ -33,5 +33,14 @@ var options = {
     element: 'span',
     className: 'firefoxtempconvertedcomplete'
 };
-instance.markRegExp(/-?\d*\.?\d+\s?\°\s?(C|F|c|f)/, options);
-convertTemps();
+var tempRegex;
+browser.storage.local.get('allowAutoAdvanced', (item) => {
+    if (item.allowAutoAdvanced) {
+        tempRegex = /-?\d*\.?\d+\s?\°?\s?(C|F|c|f)/;
+    }
+    else {
+        tempRegex = /-?\d*\.?\d+\s?\°\s?(C|F|c|f)/;
+    }
+    instance.markRegExp(tempRegex, options);
+    convertTemps();
+});


### PR DESCRIPTION
And add allow/deny option in add-on preferences.
Functionality **defaults to off**, and needs to be switched on before it starts functioning.

Fixes issue #5.