### PR TITLE
Disable advanced automatic convert setting

### DIFF
--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -8,6 +8,7 @@
         <title>Temperature Converter Preferences</title>
         <meta charset="utf-8">
         <link rel="stylesheet" href="../lib/new_browser_style.css">
+        <link rel="stylesheet" href="style.css">
     </head>
     <body class="browser-style">
         <form name="settings">
@@ -22,16 +23,15 @@
                 Scan website for temperatures and insert the converted temperature automatically
             </section>
             <div class="panel-section-separator"></div>
-            <section class="panel-section has-help">
+            <section class="panel-section has-help sub">
                 <label>Automatically convert temperatures - Advanced</label>
                 <div>
                     <label><input type="radio" name="allowAutoAdvanced" value="true"> Allow</label>
                     <label><input type="radio" name="allowAutoAdvanced" value="false"> Deny</label>
                 </div>
             </section>
-            <section class="panel-section help-row">
-                Expand the automatic converting of temperatures to include temperatures formatted without degree symbol (e.g. "180C" or "180 c")<br>
-                Only applies if "Automatically convert temperatures" is set to "Allow"
+            <section class="panel-section help-row sub">
+                Expand the automatic converting of temperatures to include temperatures formatted without degree symbol (e.g. "180C" or "180 c")
             </section>
         </form>
         <script src="options.js"></script>

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -21,7 +21,7 @@
             <section class="panel-section help-row">
                 Scan website for temperatures and insert the converted temperature automatically
             </section>
-            <hr>
+            <div class="panel-section-separator"></div>
             <section class="panel-section has-help">
                 <label>Automatically convert temperatures - Advanced</label>
                 <div>

--- a/firefox/options/options.html
+++ b/firefox/options/options.html
@@ -5,6 +5,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <title>Temperature Converter Preferences</title>
         <meta charset="utf-8">
         <link rel="stylesheet" href="../lib/new_browser_style.css">
     </head>

--- a/firefox/options/options.js
+++ b/firefox/options/options.js
@@ -8,17 +8,28 @@ function saveOptions() {
         allowAuto: toBoolean(document.settings.allowAuto.value),
         allowAutoAdvanced: toBoolean(document.settings.allowAutoAdvanced.value)
     });
+    updateUI();
 }
 
 // Load settings from storage
 function restoreOptions(item) {
     document.settings.allowAuto.value = item.allowAuto;
     document.settings.allowAutoAdvanced.value = item.allowAutoAdvanced;
+    updateUI();
 }
 
 // Convert string to boolean
 function toBoolean(string) {
     return string == 'true';
+}
+
+// Updates the UI based on the user settings
+function updateUI() {
+    const allowAutoEnabled = toBoolean(document.settings.allowAuto.value);
+    for (i = 0; i < document.settings.allowAutoAdvanced.length; i++) {
+        document.settings.allowAutoAdvanced[i].disabled = !allowAutoEnabled;
+        document.settings.allowAutoAdvanced[i].title = (!allowAutoEnabled) ? "Automatically convert temperatures must be allowed" : "";
+    }
 }
 
 browser.storage.local.get(['allowAuto', 'allowAutoAdvanced'], restoreOptions);

--- a/firefox/options/options.js
+++ b/firefox/options/options.js
@@ -18,11 +18,7 @@ function restoreOptions(item) {
 
 // Convert string to boolean
 function toBoolean(string) {
-    if (string == 'true') {
-        return true;
-    } else {
-        return false;
-    }
+    return string == 'true';
 }
 
 browser.storage.local.get(['allowAuto', 'allowAutoAdvanced'], restoreOptions);

--- a/firefox/options/style.css
+++ b/firefox/options/style.css
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* Indent sub-settings */
+.sub {
+    padding-left: 2em !important;
+}
+
+/* Change cursor for disabled settings */
+input[type="radio"]:disabled {
+    cursor: not-allowed;
+}


### PR DESCRIPTION
The advanced option for the automatic convert feature is now disabled if the base setting is not enabled. The setting is also indented to make it clear that it's a sub-setting. Closes #9.